### PR TITLE
Add "paddingTop" option for fixed menus

### DIFF
--- a/jquery.nav.js
+++ b/jquery.nav.js
@@ -42,6 +42,7 @@
 			filter: '',
 			scrollSpeed: 750,
 			scrollThreshold: 0.5,
+			paddingTop: 0,
 			begin: false,
 			end: false,
 			scrollChange: false
@@ -200,6 +201,7 @@
 
 		scrollTo: function(target, callback) {
 			var offset = $(target).offset().top;
+			offset -= this.config.paddingTop;
 
 			$('html, body').animate({
 				scrollTop: offset


### PR DESCRIPTION
I made this update in the code because I needed to add some paddingTop for the plugin. I have a fixed menu and I needed to have this option to compensate the menu height.
So, I just added 2 lines of code to make it works.
It's really simple, but I think it would be usefull for the plugin and everyone who use it.